### PR TITLE
fix: hero squashing on windows with a small height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -62,6 +62,13 @@ header {
 	gap: 2em;
 }
 
+@media only screen and (min-width: 1001px) {
+	header > .container {
+		margin-top: 96px;
+		margin-bottom: 32px;
+	}
+}
+
 header > .container .event-date {
 	font-size: 2em;
 }


### PR DESCRIPTION
This should resolve #2 by adding a margin to the top of the hero when not in the mobile view.  A slightly smaller margin is also added to the bottom to avoid pushing the element too far off-centre downwards. This also has the side effect of centring the element a little better vertically (before: https://i.imgur.com/1lZCKgI.png, after: https://i.imgur.com/O287Jc1.png).